### PR TITLE
Fix trailing backtick lines

### DIFF
--- a/tests/test_make_chat.py
+++ b/tests/test_make_chat.py
@@ -152,4 +152,3 @@ def test_make_chat_basic(tmp_path):
     # 8 vocab lines, 5 other lines. Total ~24-25 sentences.
     # The test script currently logs "Detected X dialogue/vocab/other segments" based on matching these sentences.
     # This is what we are asserting above.
-```

--- a/tests/test_merge_weight.py
+++ b/tests/test_merge_weight.py
@@ -126,4 +126,3 @@ def test_merge_weight_basic(tmp_path):
     assert "Successfully wrote validation set." in log_content
     assert "Processing complete." in log_content
 
-```


### PR DESCRIPTION
## Summary
- clean up stray triple-backtick lines in tests

## Testing
- `python -m py_compile tests/test_make_chat.py`
- `python -m py_compile tests/test_merge_weight.py`

------
https://chatgpt.com/codex/tasks/task_e_684368257494832bb6439563cdd7b572