### PR TITLE
Fix quoting in ASR fine-tune notebook

### DIFF
--- a/notebooks/runyoro_bible_asr_finetune.ipynb
+++ b/notebooks/runyoro_bible_asr_finetune.ipynb
@@ -478,7 +478,7 @@
     "    display(Markdown(f\"Hyperparameters file generated: `{current_hparams_file}`\"))\n",
     "    display(Markdown(f\"**Content:**\n",
     "```yaml\n",
-    f"{yaml.dump(hparams_content, sort_keys=False, indent=2)}\n",
+    "    f\"{yaml.dump(hparams_content, sort_keys=False, indent=2)}\n",
     "```\"))\n",
     "    return current_hparams_file\n",
     "\n",


### PR DESCRIPTION
## Summary
- fix quoting for YAML dump in `runyoro_bible_asr_finetune.ipynb`

## Testing
- `jupyter nbconvert --to notebook --stdout notebooks/runyoro_bible_asr_finetune.ipynb`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydub')*

------
https://chatgpt.com/codex/tasks/task_e_6843577fb2f4832b8b5a75f5dfe5ea0f