### PR TITLE
Add manual ASR fine-tuning notebook

### DIFF
--- a/notebooks/manual_bible_asr_finetune.ipynb
+++ b/notebooks/manual_bible_asr_finetune.ipynb
@@ -1,0 +1,235 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c0166fde",
+   "metadata": {},
+   "source": [
+    "# Manual Bible ASR Fine-tuning (No API Key)\n",
+    "\n",
+    "This notebook demonstrates how to fine-tune the Runyoro HuBERT-style model using manually downloaded Bible audio and text. It mirrors the workflow from `1_data_download_and_manifest_creation.ipynb` and `runyoro_bible_asr_finetune.ipynb` but avoids the Digital Bible Platform API.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3ef34530",
+   "metadata": {},
+   "source": [
+    "## Install Dependencies\n",
+    "Run this once to install the libraries required for scraping, audio handling and SpeechBrain.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d6399f86",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install requests beautifulsoup4 soundfile torch torchaudio speechbrain PyYAML"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bcde20d",
+   "metadata": {},
+   "source": [
+    "## Path Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e1babd8b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from pathlib import Path\n",
+    "\n",
+    "PROJECT_ROOT = Path.cwd().parent  # assume notebook lives in notebooks/\n",
+    "DATA_DIR = PROJECT_ROOT / 'data' / 'bible_manual'\n",
+    "AUDIO_DIR = DATA_DIR / 'audio'\n",
+    "TEXT_DIR = DATA_DIR / 'text'\n",
+    "AUDIO_FILESET_ID = 'NYOBSUN2DA'\n",
+    "TEXT_FILESET_ID = 'NYOBSUN2DA_TEXT'\n",
+    "\n",
+    "AUDIO_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "TEXT_DIR.mkdir(parents=True, exist_ok=True)\n",
+    "print('Project root:', PROJECT_ROOT)\n",
+    "print('Data dir:', DATA_DIR)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1fbfbf06",
+   "metadata": {},
+   "source": [
+    "## Download Audio Zip\n",
+    "The audio is hosted as a pre-zipped archive. Update `audio_zip_url` if the link expires.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c6398dae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests, zipfile\n",
+    "zip_path = AUDIO_DIR / f'{AUDIO_FILESET_ID}.zip'\n",
+    "audio_zip_url = 'https://d1gd73roq7kqw6.cloudfront.net/audio/NYOBSU/NYOBSUN2DA/NYOBSUN2DA.zip?x-amz-transaction=6944150&Expires=1749382538&Signature=X1IFdAguEgRkF4SIG5bmdFjfTaOCb6UHQ6NDonTvJznDmaYPkEBVU2v9zT87IN5GDYzPqv3Eom~L1vPEh-YrIzDNAIecnePJAUJ96VEaVrOFE9mudBEjSMLFI5m6Gzm4YaHgx1g7SEPSP5QIu6bTqkzB2d5fCTJsB9Yt9O6u2mKx9j3zloo9gc43qyKW-SzJMfWbZhBkEPR~dkKA3my5SDVVeO21ZpODgIp1O9TETjVTx6--fauwoxpbMgI9NXTUvFWt2zD7BWVxgkPAY2IGDuKoX~H4xNJwn7eF4TZeqK3Udkx7LrM5WmNVMfOHTN5E68vWERY37l4kYZpP~pIB6g__&Key-Pair-Id=APKAI4ULLVMANLYYPTLQ'\n",
+    "\n",
+    "if not zip_path.exists():\n",
+    "    print('Downloading audio zip...')\n",
+    "    with requests.get(audio_zip_url, stream=True) as r:\n",
+    "        r.raise_for_status()\n",
+    "        with open(zip_path, 'wb') as f:\n",
+    "            for chunk in r.iter_content(chunk_size=8192):\n",
+    "                f.write(chunk)\n",
+    "else:\n",
+    "    print('Audio zip already present.')\n",
+    "\n",
+    "extract_dir = AUDIO_DIR / AUDIO_FILESET_ID\n",
+    "if not extract_dir.exists():\n",
+    "    print('Extracting zip...')\n",
+    "    with zipfile.ZipFile(zip_path, 'r') as zf:\n",
+    "        zf.extractall(extract_dir)\n",
+    "else:\n",
+    "    print('Audio already extracted.')\n",
+    "print('Audio ready in', extract_dir)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6874d90",
+   "metadata": {},
+   "source": [
+    "## Scrape Text from Bible.is\n",
+    "This example grabs text for Mark chapter 1. Extend the loop to fetch more chapters if desired.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dae1adfa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "text_base = TEXT_DIR / TEXT_FILESET_ID\n",
+    "text_base.mkdir(parents=True, exist_ok=True)\n",
+    "\n",
+    "headers = {'User-Agent': 'Mozilla/5.0'}\n",
+    "\n",
+    "def fetch_chapter(book, chapter):\n",
+    "    url = f'https://live.bible.is/bible/NYOBSU/{book}/{chapter}'\n",
+    "    resp = requests.get(url, headers=headers)\n",
+    "    resp.raise_for_status()\n",
+    "    soup = BeautifulSoup(resp.text, 'html.parser')\n",
+    "    text = soup.get_text(separator=' ')\n",
+    "    text = ' '.join(text.split())\n",
+    "    return text\n",
+    "\n",
+    "for ch in [1]:\n",
+    "    txt = fetch_chapter('MRK', ch)\n",
+    "    out_file = text_base / f'MRK_{ch:03d}.txt'\n",
+    "    with open(out_file, 'w', encoding='utf-8') as f:\n",
+    "        f.write(txt)\n",
+    "    print('Wrote', out_file)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b19bc23d",
+   "metadata": {},
+   "source": [
+    "## Build SpeechBrain Manifest"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c2f17aae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "manifest_path = DATA_DIR / 'manual_manifest.json'\n",
+    "!python runyoro_speech_ai/asr_finetune/build_manifest.py     --audio_dir_base {AUDIO_DIR}     --text_dir_base {TEXT_DIR}     --audio_fileset_id {AUDIO_FILESET_ID}     --text_fileset_id {TEXT_FILESET_ID}     --manifest_path {manifest_path}     --language_code nyo\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd334c67",
+   "metadata": {},
+   "source": [
+    "## Prepare Hyperparameters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b063cc58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import yaml\n",
+    "hparams_dir = PROJECT_ROOT / 'asr_manual_finetune'\n",
+    "hparams_dir.mkdir(parents=True, exist_ok=True)\n",
+    "hparams_file = hparams_dir / 'hparams_finetune.yaml'\n",
+    "\n",
+    "hparams = {\n",
+    "    'seed': 1234,\n",
+    "    'data_folder': str(DATA_DIR),\n",
+    "    'output_folder': str(hparams_dir),\n",
+    "    'save_folder': '!ref <output_folder>/save',\n",
+    "    'train_manifest': manifest_path.name,\n",
+    "    'valid_manifest': manifest_path.name,\n",
+    "    'test_manifest': manifest_path.name,\n",
+    "    'tokenizer_model_dir': '!ref <save_folder>/tokenizer/',\n",
+    "    'tokenizer_model_prefix': 'spm_unigram_1000',\n",
+    "    'tokenizer_vocab_size': 1000,\n",
+    "    'ssl_model_hub': 'facebook/wav2vec2-base',\n",
+    "    'ssl_local_checkpoint_path': '/path/to/ssl_checkpoint.ckpt',\n",
+    "    'number_of_epochs': 5,\n",
+    "}\n",
+    "with open(hparams_file, 'w') as f:\n",
+    "    yaml.dump(hparams, f, sort_keys=False)\n",
+    "print('Hparams saved to', hparams_file)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "61859840",
+   "metadata": {},
+   "source": [
+    "## Start ASR Fine-tuning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa07fb43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!python runyoro_speech_ai/asr_finetune/train_ctc.py {hparams_file}\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a notebook that shows how to fine‑tune the Runyoro HuBERT-style model without using a DBP API key

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684426ed1dd0832b877e979fd29991bc