### PR TITLE
Update text scraping to parse audio filenames

### DIFF
--- a/notebooks/manual_bible_asr_finetune.ipynb
+++ b/notebooks/manual_bible_asr_finetune.ipynb
@@ -106,7 +106,7 @@
    "metadata": {},
    "source": [
     "## Scrape Text from Bible.is\n",
-    "This example grabs text for Mark chapter 1. Extend the loop to fetch more chapters if desired.\n"
+    "Parse the audio filenames to know which book and chapter pairs exist, then fetch matching text for each one.\n"
    ]
   },
   {
@@ -117,6 +117,8 @@
    "outputs": [],
    "source": [
     "import requests\n",
+    "import re\n",
+    "from collections import defaultdict\n",
     "from bs4 import BeautifulSoup\n",
     "\n",
     "text_base = TEXT_DIR / TEXT_FILESET_ID\n",
@@ -133,12 +135,22 @@
     "    text = ' '.join(text.split())\n",
     "    return text\n",
     "\n",
-    "for ch in [1]:\n",
-    "    txt = fetch_chapter('MRK', ch)\n",
-    "    out_file = text_base / f'MRK_{ch:03d}.txt'\n",
-    "    with open(out_file, 'w', encoding='utf-8') as f:\n",
-    "        f.write(txt)\n",
-    "    print('Wrote', out_file)\n"
+    "# determine available books/chapters from audio files\n",
+    "audio_dir = AUDIO_DIR / AUDIO_FILESET_ID\n",
+    "books = defaultdict(set)\n",
+    "for f in audio_dir.glob(\"*.*\"):\n",
+    "    m = re.match(rf\"{AUDIO_FILESET_ID}_(\\w+)_(\\d+)\", f.stem)\n",
+    "    if m:\n",
+    "        book_id, chapter = m.groups()\n",
+    "        books[book_id].add(int(chapter))\n",
+    "\n",
+    "for book_id, chapters in books.items():\n",
+    "    for ch in sorted(chapters):\n",
+    "        txt = fetch_chapter(book_id, ch)\n",
+    "        out_path = text_base / f\"{book_id}_{ch:03d}.txt\"\n",
+    "        with open(out_path, 'w', encoding='utf-8') as f:\n",
+    "            f.write(txt)\n",
+    "        print('Wrote', out_path)\n"
    ]
   },
   {


### PR DESCRIPTION
The “Scrape Text from Bible.is” section now guides users to parse audio filenames so that text is fetched for every chapter present in the downloaded audio

A new loop reads each audio file, extracts the book and chapter identifiers, scrapes the matching Bible text, and saves it to disk